### PR TITLE
mismatched destination corrected

### DIFF
--- a/pyspark_code.py
+++ b/pyspark_code.py
@@ -51,7 +51,7 @@ dropnullfields3 = DropNullFields.apply(frame = resolvechoice2, transformation_ct
 
 datasink1 = dropnullfields3.toDF().coalesce(1)
 df_final_output = DynamicFrame.fromDF(datasink1, glueContext, "df_final_output")
-datasink4 = glueContext.write_dynamic_frame.from_options(frame = df_final_output, connection_type = "s3", connection_options = {"path": "s3://bigdata-on-youtube-cleansed-euwest1-14317621-dev/youtube/raw_statistics/", "partitionKeys": ["region"]}, format = "parquet", transformation_ctx = "datasink4")
+datasink4 = glueContext.write_dynamic_frame.from_options(frame = df_final_output, connection_type = "s3", connection_options = {"path": "s3://de-on-youtube-cleansed-useast1-dev/youtube/raw_statistics/", "partitionKeys": ["region"]}, format = "parquet", transformation_ctx = "datasink4")
 
 ############################### Added by Darshil ###############################
 job.commit()


### PR DESCRIPTION
Glue job for csv to parquet pipeline had wrong destination path which doesn't match with your cleansed s3 bucket you showed in the tutorial video. People might get confused when copying it although it is not a big deal and a good opportunity for debugging.